### PR TITLE
Remove mention of LIMITEDACCESS doc in Cortex Analyst Streamlit app

### DIFF
--- a/cortex_analyst_streaming_demo.py
+++ b/cortex_analyst_streaming_demo.py
@@ -1,4 +1,3 @@
-# Public Docs: https://docs.snowflake.com/LIMITEDACCESS/snowflake-cortex/rest-api/cortex-analyst
 # This demo is not supported in SiS. You must run this streamlit locally.
 
 import json


### PR DESCRIPTION
Remove the URL of the LIMITEDACCESS doc used while the feature was in private preview.